### PR TITLE
Migrate to Python 3 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: test
+
+on:
+  push:
+  pull_request:
+  # workflow_dispatch:
+  # schedule:
+  #   - cron: "51 3 * * 6" # Runs at 03:51, only on Saturday
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu", "macos"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: latest
+      - name: Ubuntu - Install Python3 with apt
+        if: matrix.os == 'ubuntu'
+        run: sudo apt-get update && sudo apt-get install -y libpython3-dev
+      - name: MacOS - Install Python3 with Homebrew
+        if: matrix.os == 'macos'
+        run: brew install python3
+      - name: Install dependencies
+        run: shards install --without-development --release
+      - name: Build
+        run: make
+      - name: Run tests
+        run: make test
+      - name: Run executable
+        run: |
+          make examples
+          chmod +x ./build/test
+          ./build/test

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them
 /shard.lock
+
+/build/
+
+*.o
+*.a
+*.so
+*.dylib
+*.exe
+*.dll
+

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ no-debug ?= ## No symbolic debug info
 verbose ?= ## Run specs in verbose mode
 link-flags ?= ## Additional flags to pass to the linker
 
-OS := $(shell uname -s | tr '[:upper:@]' '[:lower:]')
+OS := $(LC_CTYPE=C $(shell uname -s | tr '[:upper:]' '[:lower:]'))
 
 O := build
-FLAGS := $(if $(release),--release )$(if $(stats),--stats )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(no-debug),--no-debug )$(if $(link-flags),--link-flags "$(link-flags)" )
+FLAGS := $(if $(release),--release )$(if $(stats),--stats )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(no-debug),--no-debug )
 VERBOSE := $(if $(verbose),-v )
 
 #CFLAGS += -fPIC
@@ -22,8 +22,17 @@ LIB_CRYTHON_TARGET = src/ext/libcrython.a
 
 DEPS = $(LIB_CRYTHON_TARGET)
 
-EXAMPLES_SOURCES := $(shell find examples -name '*.cr')
+EXAMPLES_SOURCES := $(shell find examples -type f -name '*.cr')
 EXAMPLES_TARGETS := $(subst examples, $(O), $(patsubst %.cr, %, $(EXAMPLES_SOURCES)))
+
+PYTHON_CFLAGS := $(shell python3-config --cflags)
+PYTHON_LDFLAGS := $(shell python3-config --ldflags)
+
+PYTHON_VERSION := $(shell python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+PYTHON_LIB := -lpython$(PYTHON_VERSION)
+
+CFLAGS += $(PYTHON_CFLAGS)
+LDFLAGS += $(PYTHON_LDFLAGS) $(PYTHON_LIB)
 
 .PHONY: all
 all: deps
@@ -42,7 +51,11 @@ $(LIB_CRYTHON_TARGET): $(LIB_CRYTHON_OBJ)
 
 $(EXAMPLES_TARGETS):
 	@mkdir -p $(O)
-	$(BUILD_PATH) crystal build $(FLAGS) $(addsuffix .cr, $(subst build, examples, $@)) -o $@
+	$(BUILD_PATH) crystal build $(FLAGS) $(addsuffix .cr, $(subst build, examples, $@)) --link-flags "$(LDFLAGS)" -o $@
+
+.PHONY: test
+test: deps ## Run tests
+	$(BUILD_PATH) crystal spec $(VERBOSE) --link-flags "$(LDFLAGS)"
 
 .PHONY: examples
 examples: $(DEPS) $(EXAMPLES_TARGETS)

--- a/shard.yml
+++ b/shard.yml
@@ -7,8 +7,6 @@ authors:
 description: |
   Crystal meets Python
 
-crystal: 0.27.0
-
 scripts:
   postinstall: make release=1
 

--- a/src/crython/libpython.cr
+++ b/src/crython/libpython.cr
@@ -1,4 +1,4 @@
-@[Link("python")]
+@[Link("python3")]
 lib LibPython
   alias PyObject = Void*
   alias Int = LibC::Int
@@ -17,7 +17,7 @@ lib LibPython
 
   fun error_clear = PyErr_Clear
   fun error_occurred = PyErr_Occurred : PyObject
-  fun error_print = PyErr_print
+  fun error_print = PyErr_Print
 
   fun import_module = PyImport_ImportModule(Char*) : PyObject
 
@@ -35,6 +35,9 @@ lib LibPython
   fun string_size = PyString_Size(o : PyObject) : Int
   fun string_as_cstring = PyString_AsString(str : PyObject) : Char*
   fun string_from_cstring = PyString_FromStringAndSize(str : Char*, size : Int)
+  fun string_size = PyUnicode_GetLength(o : PyObject) : Int
+  fun string_as_cstring = PyUnicode_AsUTF8(str : PyObject) : Char*
+  fun string_from_cstring = PyUnicode_FromStringAndSize(str : Char*, size : Int)
 
   fun list_new = PyList_New(size : Int) : PyObject
   fun list_size = PyList_Size(list : PyObject) : Int
@@ -43,5 +46,5 @@ lib LibPython
 
   fun tuple_get = PyTuple_GetItem(t : PyObject, i : Int) : PyObject
 
-  fun int_as_long = PyInt_AsLong(i : PyObject) : Long
+  fun int_as_long = PyLong_AsLong(i : PyObject) : Long
 end

--- a/src/ext/crython.c
+++ b/src/ext/crython.c
@@ -1,15 +1,5 @@
-#ifdef __APPLE__
-    #include <AvailabilityMacros.h>
-    #if MAC_OS_X_VERSION_MAX_ALLOWED < 101300
-        #include <Python/Python.h>
-    #else
-        #include <Python2.7/Python.h>
-    #endif
-#else
-    #include <python2.7/Python.h>
-#endif
+#include <Python.h>
 
-/* Expose reference counting macros */
 
 extern void py_incref(PyObject *o) {
   Py_INCREF(o);
@@ -40,7 +30,7 @@ extern PyObject* py_none() {
 extern PyObject *load_module(char *module_name) {
   PyObject *pName, *pModule;
 
-  pName = PyString_FromString(module_name);
+  pName = PyUnicode_FromString(module_name);
   /* Error checking of pName left out */
 
   pModule = PyImport_Import(pName);


### PR DESCRIPTION
> Hi!
> 
> It has been a while.
> I was looking for a library to call Python in Crystal and found this project.
> 
> I made minimal changes to make it work with Python 3.
> (This change does not support Python2)
> 
> Thank you.
> 

The previous pull request incorrectly included a Linux binary file (. /build/test) was incorrectly included. Also, the test failed on MacOS. So I made a fix and split it into commits a bit more cleanly. I would be happy for you to review it.